### PR TITLE
🐛Fix: Docker Release Permissions

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -7,13 +7,13 @@ on:
     tags:
       - 'v[0-9]+.[0-9]+.[0-9]+'
 
-permissions:
-  contents: write
-
 jobs:
   goreleaser:
     runs-on: ubuntu-latest
     if: github.ref_type == 'tag'
+
+    permissions:
+      contents: write
 
     steps:
       - uses: actions/checkout@v3
@@ -32,6 +32,10 @@ jobs:
 
   push_docker_image:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      packages: write
 
     steps:
       - uses: actions/checkout@v3


### PR DESCRIPTION
Fixing permissions for each job based on [GHA workflow failure]( https://github.com/alehechka/kube-secret-sync/actions/runs/2953091033).