### PR TITLE
Force update added secrets when data differs

### DIFF
--- a/client/secrets.go
+++ b/client/secrets.go
@@ -118,9 +118,7 @@ func getSecret(ctx context.Context, clientset *kubernetes.Clientset, namespace, 
 func secretsAreEqual(a, b *v1.Secret) bool {
 	return (a.Type == b.Type &&
 		reflect.DeepEqual(a.Data, b.Data) &&
-		reflect.DeepEqual(a.StringData, b.StringData) &&
-		reflect.DeepEqual(a.Labels, b.Labels) &&
-		reflect.DeepEqual(a.Annotations, b.Annotations))
+		reflect.DeepEqual(a.StringData, b.StringData))
 }
 
 func prepareSecret(namespace v1.Namespace, secret *v1.Secret) *v1.Secret {

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -50,7 +50,7 @@ func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *Sy
 		if namespaceSecret, err := getSecret(ctx, clientset, namespace.Name, secret.Name); err == nil {
 			log.Debugf("Secret already exists: %s/%s", namespace.Name, secret.Name)
 
-			if reflect.DeepEqual(namespaceSecret.Data, secret.Data) {
+			if secretsAreEqual(secret, namespaceSecret) {
 				log.Debugf("Existing secret contains same data: %s/%s", namespace.Name, secret.Name)
 				continue
 			}
@@ -137,4 +137,12 @@ func updateSecret(ctx context.Context, clientset *kubernetes.Clientset, namespac
 
 func getSecret(ctx context.Context, clientset *kubernetes.Clientset, namespace, name string) (*v1.Secret, error) {
 	return clientset.CoreV1().Secrets(namespace).Get(ctx, name, metav1.GetOptions{})
+}
+
+func secretsAreEqual(a, b *v1.Secret) bool {
+	return (a.Type == b.Type &&
+		reflect.DeepEqual(a.Data, b.Data) &&
+		reflect.DeepEqual(a.StringData, b.StringData) &&
+		reflect.DeepEqual(a.Labels, b.Labels) &&
+		reflect.DeepEqual(a.Annotations, b.Annotations))
 }

--- a/k8s/2_deployment.yaml
+++ b/k8s/2_deployment.yaml
@@ -23,6 +23,12 @@ spec:
           env:
             - name: DEBUG
               value: 'true'
+            - name: SECRETS_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+            - name: EXCLUDE_NAMESPACES
+              value: kube-system, kube-public, kube-node-lease
           resources:
             requests:
               cpu: 0.1


### PR DESCRIPTION
This PR encompasses the force updating of all added secrets when the secret name exists within a selected namespace but the data differs. With the implementation here, the secret will be deleted and recreated with the newer secret's data. 

This PR also updates the sync process to append a `managed-by` annotation to all created/updated secrets.

It is planned to add an env variable option to turn off this forced update.

Relates to:
- #1 