### PR TITLE
Add force flag to force updates on non-managed secrets

### DIFF
--- a/client/config.go
+++ b/client/config.go
@@ -47,6 +47,8 @@ type SyncConfig struct {
 
 	SecretsNamespace string
 
+	ForceSync bool
+
 	OutOfCluster bool
 	KubeConfig   string
 }

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -55,7 +55,7 @@ func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *Sy
 				continue
 			}
 
-			if secretsAreEqual(secret, namespaceSecret) {
+			if isManagedBy(namespaceSecret) && secretsAreEqual(secret, namespaceSecret) {
 				log.Debugf("Existing secret contains same data: %s/%s", namespace.Name, secret.Name)
 				continue
 			}

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -50,6 +50,11 @@ func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *Sy
 		if namespaceSecret, err := getSecret(ctx, clientset, namespace.Name, secret.Name); err == nil {
 			log.Debugf("Secret already exists: %s/%s", namespace.Name, secret.Name)
 
+			if !config.ForceSync && !isManagedBy(namespaceSecret) {
+				log.Debugf("Existing secret is not managed and will not be force updated: %s/%s", namespace.Name, secret.Name)
+				continue
+			}
+
 			if secretsAreEqual(secret, namespaceSecret) {
 				log.Debugf("Existing secret contains same data: %s/%s", namespace.Name, secret.Name)
 				continue
@@ -126,7 +131,7 @@ func prepareSecret(namespace v1.Namespace, secret *v1.Secret) *v1.Secret {
 	if annotations == nil {
 		annotations = make(map[string]string)
 	}
-	annotations["managed-by"] = "kube-secret-sync"
+	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
 
 	return &v1.Secret{
 		TypeMeta: secret.TypeMeta,
@@ -142,4 +147,10 @@ func prepareSecret(namespace v1.Namespace, secret *v1.Secret) *v1.Secret {
 		Type:       secret.Type,
 	}
 
+}
+
+func isManagedBy(secret *v1.Secret) bool {
+	managedBy, ok := secret.Annotations[constants.ManagedByAnnotationKey]
+
+	return ok && managedBy == constants.ManagedByAnnotationValue
 }

--- a/cmd/start.go
+++ b/cmd/start.go
@@ -20,6 +20,7 @@ const (
 	secretsNamespaceFlag  = "secrets-namespace"
 	outOfClusterFlag      = "out-of-cluster"
 	kubeconfigFlag        = "kubeconfig"
+	forceSyncFlag         = "force"
 )
 
 func kubeconfig() *cli.StringFlag {
@@ -71,6 +72,11 @@ var startFlags = []cli.Flag{
 		Usage:   "Will use the default ~/.kube/config file on the local machine to connect to the cluster externally.",
 		Aliases: []string{"local"},
 	},
+	&cli.BoolFlag{
+		Name:    forceSyncFlag,
+		Usage:   "Forces synchronization of all secrets, not just kube-secret-sync managed secrets.",
+		EnvVars: []string{"FORCE"},
+	},
 }
 
 func startKubeSecretSync(ctx *cli.Context) (err error) {
@@ -86,6 +92,8 @@ func startKubeSecretSync(ctx *cli.Context) (err error) {
 		IncludeNamespaces: ctx.StringSlice(includeNamespacesFlag),
 
 		SecretsNamespace: ctx.String(secretsNamespaceFlag),
+
+		ForceSync: ctx.Bool(forceSyncFlag),
 
 		OutOfCluster: ctx.Bool(outOfClusterFlag),
 		KubeConfig:   ctx.String(kubeconfigFlag),

--- a/constants/annotations.go
+++ b/constants/annotations.go
@@ -1,0 +1,7 @@
+package constants
+
+// ManagedByAnnotationKey is an annotation key appended to kube-secret-sync managed secrets.
+const ManagedByAnnotationKey = "app.kubernetes.io/managed-by"
+
+// ManagedByAnnotationValue is an annotation value appended to kube-secret-sync managed secrets.
+const ManagedByAnnotationValue = "kube-secret-sync"


### PR DESCRIPTION
Previously, synchronized secrets were annotated with a `managed-by` key/value to signify how it was created. The key has been slightly altered with this PR. However, the existence of this annotation makes it very easy to check which secrets were originally created with `kube-secret-sync` and thus can be automatically synced. Adding the `--force` flag here simply makes it so all secrets will managed and thus synced from the SecretsNamespace.