### PR TITLE
Synchronize Modified Secrets

### DIFF
--- a/client/sync.go
+++ b/client/sync.go
@@ -7,6 +7,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
+	"k8s.io/client-go/kubernetes"
 )
 
 // SyncSecrets syncs Secrets across all selected Namespaces
@@ -40,4 +41,24 @@ func SyncSecrets(config *SyncConfig) (err error) {
 	}
 
 	return nil
+}
+
+func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
+	log.Infof("Secret added: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+
+	return syncSecret(ctx, clientset, config, secret)
+}
+
+func modifySecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
+	if secret.DeletionTimestamp != nil {
+		return nil
+	}
+
+	log.Infof("Secret modified: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+
+	return syncSecret(ctx, clientset, config, secret)
+}
+
+func deleteSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) {
+	log.Infof("Secret deleted: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 }


### PR DESCRIPTION
The main purpose of this PR is to synchronize modified secrets. This was made very easy by reusing the entirety of the `addSecrets` function (now renamed as `syncSecret`). Additionally, the original `modifySecrets` function now checks for the existence of the DeletionTimestamp, in which case it will do nothing because that secret has been marked for deletion. 

Finally, to easily test the modified secrets process, I was adding/deleting an annotation from my test secret. I found that the `areSecretsEqual` function was not covering the equality of annotations and thus new functionality was added to it. Now mismatching annotations (outside of the self-created `managed-by` annotation) will be considered unequal.