### PR TITLE
Sync deleted secrets

### DIFF
--- a/client/sync.go
+++ b/client/sync.go
@@ -46,7 +46,7 @@ func SyncSecrets(config *SyncConfig) (err error) {
 func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
 	log.Infof("Secret added: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 
-	return syncSecret(ctx, clientset, config, secret)
+	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
 }
 
 func modifySecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
@@ -56,9 +56,11 @@ func modifySecrets(ctx context.Context, clientset *kubernetes.Clientset, config 
 
 	log.Infof("Secret modified: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 
-	return syncSecret(ctx, clientset, config, secret)
+	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
 }
 
 func deleteSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) {
 	log.Infof("Secret deleted: %s/%s", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+
+	syncNamespaceSecret(ctx, clientset, config, secret, syncDeletedSecret)
 }


### PR DESCRIPTION
The primary purpose of this PR is to sync the deletion of secrets across selected namespaces. This was accomplished with the new `syncDeletedSecret` function.

Additionally, the `syncSecret` function was refactored as `syncNamespaceSecret` and now takes in a *callback* function that will be called after all secret/namespace validation is performed. Doing it this way allows `Added`/`Modified`/`Deleted` to all use the same validation/looping code and be able to pass in their own syncing function. 
