### PR TITLE
Add Namespace watcher for created namespaces

### DIFF
--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -3,10 +3,25 @@ package client
 import (
 	"context"
 
+	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 	"k8s.io/client-go/kubernetes"
 )
+
+func namespaceEventHandler(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, event watch.Event) {
+	namespace := event.Object.(*v1.Namespace)
+
+	switch event.Type {
+	case watch.Added:
+		addNamespace(ctx, clientset, config, namespace)
+	}
+}
+
+func addNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, namespace *v1.Namespace) {
+	log.Infof("[%s]: Namespace created", namespace.Name)
+}
 
 func listNamespaces(ctx context.Context, clientset *kubernetes.Clientset) (*v1.NamespaceList, error) {
 	return clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -8,9 +8,45 @@ import (
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/watch"
 
 	"k8s.io/client-go/kubernetes"
 )
+
+func secretEventHandler(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, event watch.Event) {
+	secret := event.Object.(*v1.Secret)
+
+	switch event.Type {
+	case watch.Added:
+		addSecrets(ctx, clientset, config, secret)
+	case watch.Modified:
+		modifySecrets(ctx, clientset, config, secret)
+	case watch.Deleted:
+		deleteSecrets(ctx, clientset, config, secret)
+	}
+}
+
+func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
+	log.Infof("[%s/%s]: Secret created", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+
+	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
+}
+
+func modifySecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
+	if secret.DeletionTimestamp != nil {
+		return nil
+	}
+
+	log.Infof("[%s/%s]: Secret modified", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+
+	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
+}
+
+func deleteSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
+	log.Infof("[%s/%s]: Secret deleted", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+
+	return syncNamespaceSecret(ctx, clientset, config, secret, syncDeletedSecret)
+}
 
 type SecretSyncFunc func(context.Context, *kubernetes.Clientset, *SyncConfig, v1.Namespace, *v1.Secret) error
 

--- a/client/sync.go
+++ b/client/sync.go
@@ -32,7 +32,7 @@ func SyncSecrets(config *SyncConfig) (err error) {
 	}
 
 	sigc := make(chan os.Signal, 1)
-	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT)
+	signal.Notify(sigc, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM, syscall.SIGQUIT, syscall.SIGKILL)
 
 	for {
 		select {

--- a/client/sync.go
+++ b/client/sync.go
@@ -21,30 +21,41 @@ func SyncSecrets(config *SyncConfig) (err error) {
 		return err
 	}
 
-	watcher, err := clientset.CoreV1().Secrets(config.SecretsNamespace).Watch(ctx, metav1.ListOptions{})
+	secretWatcher, err := clientset.CoreV1().Secrets(config.SecretsNamespace).Watch(ctx, metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for event := range watcher.ResultChan() {
-		secret := event.Object.(*v1.Secret)
-
-		switch event.Type {
-		case watch.Added:
-			addSecrets(ctx, clientset, config, secret)
-		case watch.Modified:
-			modifySecrets(ctx, clientset, config, secret)
-		case watch.Deleted:
-			deleteSecrets(ctx, clientset, config, secret)
-		}
-
+	namespaceWatcher, err := clientset.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
 	}
 
-	return nil
+	for {
+		select {
+		case secretEvent := <-secretWatcher.ResultChan():
+			secretEventHandler(ctx, clientset, config, secretEvent)
+		case namespaceEvent := <-namespaceWatcher.ResultChan():
+			namespaceEventHandler(ctx, clientset, config, namespaceEvent)
+		}
+	}
+}
+
+func secretEventHandler(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, event watch.Event) {
+	secret := event.Object.(*v1.Secret)
+
+	switch event.Type {
+	case watch.Added:
+		addSecrets(ctx, clientset, config, secret)
+	case watch.Modified:
+		modifySecrets(ctx, clientset, config, secret)
+	case watch.Deleted:
+		deleteSecrets(ctx, clientset, config, secret)
+	}
 }
 
 func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
-	log.Infof("[%s/%s]: Secret added", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+	log.Infof("[%s/%s]: Secret created", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 
 	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
 }
@@ -59,8 +70,21 @@ func modifySecrets(ctx context.Context, clientset *kubernetes.Clientset, config 
 	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
 }
 
-func deleteSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) {
+func deleteSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
 	log.Infof("[%s/%s]: Secret deleted", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 
-	syncNamespaceSecret(ctx, clientset, config, secret, syncDeletedSecret)
+	return syncNamespaceSecret(ctx, clientset, config, secret, syncDeletedSecret)
+}
+
+func namespaceEventHandler(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, event watch.Event) {
+	namespace := event.Object.(*v1.Namespace)
+
+	switch event.Type {
+	case watch.Added:
+		addNamespace(ctx, clientset, config, namespace)
+	}
+}
+
+func addNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, namespace *v1.Namespace) {
+	log.Infof("[%s]: Namespace created", namespace.Name)
 }

--- a/k8s/1_rbac.yaml
+++ b/k8s/1_rbac.yaml
@@ -28,6 +28,7 @@ rules:
     verbs:
       - list
       - get
+      - watch
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
Initially, I had planned to create the `Added` namespace sync functionality entirely, but this branch has already seen quite a few changes and I'd like to keep the PRs to a smaller scale.

The main purpose of this PR is to add a Namespace watcher that will print a log on `Added` events. I was able to accomplish this by using the `select` block within an infinite `for` loop to pull events from both the secret and namespace watchers and send the event to the new respective event handler functions.

Additionally, I added a signal watcher that will gracefully shut down things when a "kill" switch is hit.