### PR TITLE
Sync secrets to newly created namespaces

### DIFF
--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -24,19 +24,21 @@ func addNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *
 	log.Infof("[%s]: Namespace added", namespace.Name)
 
 	if namespace.CreationTimestamp.Time.Before(startTime) {
-		log.Debugf("[%s]: Namespace will be synced on startup by Secrets watcher.", namespace.Name)
+		log.Debugf("[%s]: Namespace will be synced on startup by Secrets watcher", namespace.Name)
 		return
 	}
 
-	log.Debugf("[%s]: Syncing new namespace", namespace.Name)
+	syncNamespace(ctx, clientset, config, namespace)
 }
 
 func syncNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, namespace *v1.Namespace) error {
+	log.Debugf("[%s]: Syncing new namespace", namespace.Name)
+
 	if err := verifyNamespace(config, *namespace); err != nil {
 		return err
 	}
 
-	secrets, err := listSecrets(ctx, clientset, namespace.Name)
+	secrets, err := listSecrets(ctx, clientset, config.SecretsNamespace)
 	if err != nil {
 		log.Errorf("Failed to list secrets: %s", err.Error())
 		return err

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -20,7 +20,7 @@ func namespaceEventHandler(ctx context.Context, clientset *kubernetes.Clientset,
 }
 
 func addNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, namespace *v1.Namespace) {
-	log.Infof("[%s]: Namespace created", namespace.Name)
+	log.Infof("[%s]: Namespace added", namespace.Name)
 }
 
 func listNamespaces(ctx context.Context, clientset *kubernetes.Clientset) (*v1.NamespaceList, error) {

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -3,6 +3,7 @@ package client
 import (
 	"context"
 
+	"github.com/alehechka/kube-secret-sync/constants"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -30,6 +31,53 @@ func addNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *
 	log.Debugf("[%s]: Syncing new namespace", namespace.Name)
 }
 
+func syncNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, namespace *v1.Namespace) error {
+	if err := verifyNamespace(config, *namespace); err != nil {
+		return err
+	}
+
+	secrets, err := listSecrets(ctx, clientset, namespace.Name)
+	if err != nil {
+		log.Errorf("Failed to list secrets: %s", err.Error())
+		return err
+	}
+
+	for _, secret := range secrets.Items {
+		if isInvalidSecret(config, &secret) {
+			continue
+		}
+
+		syncAddedModifiedSecret(ctx, clientset, config, *namespace, &secret)
+	}
+
+	return nil
+}
+
 func listNamespaces(ctx context.Context, clientset *kubernetes.Clientset) (*v1.NamespaceList, error) {
 	return clientset.CoreV1().Namespaces().List(ctx, metav1.ListOptions{})
+}
+
+func verifyNamespace(config *SyncConfig, namespace v1.Namespace) error {
+	if namespace.Name == config.SecretsNamespace {
+		log.Debugf("[%s]: Skipping secrets namespace", namespace.Name)
+		return constants.ErrSecretsNamespace
+	}
+
+	if config.ExcludeNamespaces.IsExcluded(namespace.Name) {
+		log.Debugf("[%s]: Namespace has been excluded from sync", namespace.Name)
+		return constants.ErrExcludedNamespace
+	}
+
+	if !config.IncludeNamespaces.IsIncluded(namespace.Name) {
+		log.Debugf("[%s]: Namespace is not included for sync", namespace.Name)
+		return constants.ErrNotIncludedNamespace
+	}
+
+	return nil
+}
+
+func isInvalidNamespace(config *SyncConfig, namespace v1.Namespace) bool {
+	err := verifyNamespace(config, namespace)
+
+	return err != nil
 }

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -21,6 +21,13 @@ func namespaceEventHandler(ctx context.Context, clientset *kubernetes.Clientset,
 
 func addNamespace(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, namespace *v1.Namespace) {
 	log.Infof("[%s]: Namespace added", namespace.Name)
+
+	if namespace.CreationTimestamp.Time.Before(startTime) {
+		log.Debugf("[%s]: Namespace will be synced on startup by Secrets watcher.", namespace.Name)
+		return
+	}
+
+	log.Debugf("[%s]: Syncing new namespace", namespace.Name)
 }
 
 func listNamespaces(ctx context.Context, clientset *kubernetes.Clientset) (*v1.NamespaceList, error) {

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -27,7 +27,7 @@ func secretEventHandler(ctx context.Context, clientset *kubernetes.Clientset, co
 }
 
 func addSecrets(ctx context.Context, clientset *kubernetes.Clientset, config *SyncConfig, secret *v1.Secret) error {
-	log.Infof("[%s/%s]: Secret created", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
+	log.Infof("[%s/%s]: Secret added", secret.ObjectMeta.Namespace, secret.ObjectMeta.Name)
 
 	return syncNamespaceSecret(ctx, clientset, config, secret, syncAddedModifiedSecret)
 }

--- a/client/sync.go
+++ b/client/sync.go
@@ -5,14 +5,19 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var startTime time.Time
+
 // SyncSecrets syncs Secrets across all selected Namespaces
 func SyncSecrets(config *SyncConfig) (err error) {
 	ctx := context.Background()
+
+	startTime = time.Now()
 
 	log.Debugf("Starting with following configuration: %#v", *config)
 

--- a/constants/errors.go
+++ b/constants/errors.go
@@ -7,3 +7,12 @@ var ErrExcludedSecret = errors.New("secret was marked as excluded")
 
 // ErrNotIncludedSecret is the error returned when an event for a Secret that is not included is triggered.
 var ErrNotIncludedSecret = errors.New("secret was not marked as included")
+
+// ErrExcludedNamespace is the error returned when an event for a Namespace that has been excluded is triggered.
+var ErrExcludedNamespace = errors.New("namespaces was not marked as included")
+
+// ErrNotIncludedNamespace is the error returned when an event for a Namespace that is not included is triggered.
+var ErrNotIncludedNamespace = errors.New("namespaces was not marked as included")
+
+// ErrSecretsNamespace is the error returned when an event for the Namespace that secrets are synced from is triggered.
+var ErrSecretsNamespace = errors.New("namespace is used to sync secrets from")


### PR DESCRIPTION
The bulk of this PR is to introduce the syncing of secrets to newly created namespace. This is done by utilizing the namespaceWatcher to perform the sync on `Added` events. With this, it first performs a check against the CreationTimestamp to see if it was create before or after startup. This is because any namespaces that existed during startup will already be synced by the secretWatcher on startup (no need to double up the work here). If the namespace is newer, then it will attempt to sync all secrets from the desired namespace. 

To make the sync code simpler, I refactored a lot of the syncing secrets logic into smaller functions that can be reused for both (mainly the verification logic of namespaces/secrets). 

The final result is essentially no major change (outside of fixing some annotation equality checks) to the secret sync logic, and the addition of syncing secrets to newly created namespaces.