### PR TITLE
Regular Expression Matching

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -24,9 +24,6 @@ jobs:
       - name: Install dependencies
         run: go mod download
 
-      - name: Build Executable
-        run: go build cmd/kube-secret-sync/main.go
-
       - name: Run unit tests
         run: go test ./... --cover
 

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+start-regex:
+	go run cmd/kube-secret-sync/main.go start \
+		--exclude-regex-namespaces="kube[.]*" \
+		--include-regex-namespaces="default[.]*" \
+		--include-regex-secrets="test[.]*" \
+		--exclude-regex-secrets "image-[.]*" \
+		--local --debug \
+		--secrets-namespace kube-secret-sync

--- a/README.md
+++ b/README.md
@@ -10,12 +10,16 @@ By using the example yamls out-of-the-box, a new `kube-secret-sync` namespace wi
 
 ## Configuration Options
 
-| Environment Variable | Example | Type | Default | Description |
-| -------------------- | ------- | ---- | ------- | ----------- |
-| `SECRETS_NAMESPACE`  | `custom-secret-namespace` | `string` | `default` | Specifies which namespace to sync secrets from. |
-| `EXCLUDE_SECRETS`    | `do-not-sync, super-secret` | `string(csv)` | | Excludes specific Secrets from syncing. Will override **included** Secrets if specified in both. |
-| `INCLUDE_SECRETS`    | `syncable-secret, other-secret` | `string(csv)` | | Includes specific Secrets in syncing. Acts as a whitelist and all other Secrets will not be synced. |
-| `EXCLUDE_NAMESPACES` | `kube-system, kube-public` | `string(csv)` | | Excludes specific Namespaces from syncing. Will override **included** Namespaces if specified in both. |
-| `INCLUDE_NAMESPACES` | `default, my-namespace` | `string(csv)` | | Includes specific Namespaces in syncing. Acts as a whitelist and all other Namespaces will not be synced. |
-| `DEBUG` | `true` | `boolean` | `false` | Log debug messages. |
-| `FORCE` | `true` | `boolean` | `false` | Forces synchronization of all secrets, not just kube-secret-sync managed secrets. |
+| Environment Variable       | Example                         | Type          | Default   | Description                                                                                                                    |
+| -------------------------- | ------------------------------- | ------------- | --------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| `SECRETS_NAMESPACE`        | `custom-secret-namespace`       | `string`      | `default` | Specifies which namespace to sync secrets from.                                                                                |
+| `EXCLUDE_SECRETS`          | `do-not-sync, super-secret`     | `string(csv)` |           | Excludes specific Secrets from syncing. Will override **included** Secrets if specified in both.                               |
+| `INCLUDE_SECRETS`          | `syncable-secret, other-secret` | `string(csv)` |           | Includes specific Secrets in syncing. Acts as a whitelist and all other Secrets will not be synced.                            |
+| `EXCLUDE_NAMESPACES`       | `kube-system, kube-public`      | `string(csv)` |           | Excludes specific Namespaces from syncing. Will override **included** Namespaces if specified in both.                         |
+| `INCLUDE_NAMESPACES`       | `default, my-namespace`         | `string(csv)` |           | Includes specific Namespaces in syncing. Acts as a whitelist and all other Namespaces will not be synced.                      |
+| `EXCLUDE_REGEX_SECRETS`    | `skip-[.]*`                     | `string(csv)` |           | Excludes specific Secrets from syncing using regex matching. Will override **included** Secrets if specified in both.          |
+| `INCLUDE_REGEX_SECRETS`    | `syncable-[.]*`                 | `string(csv)` |           | Includes specific Secrets in syncing using regex matching. Acts as a whitelist and all other Secrets will not be synced.       |
+| `EXCLUDE_REGEX_NAMESPACES` | `kube-[.]*`                     | `string(csv)` |           | Excludes specific Namespaces from syncing using regex matching. Will override **included** Namespaces if specified in both.    |
+| `INCLUDE_REGEX_NAMESPACES` | `syncable-[.]*`                 | `string(csv)` |           | Includes specific Namespaces in syncing using regex matching. Acts as a whitelist and all other Namespaces will not be synced. |
+| `DEBUG`                    | `true`                          | `boolean`     | `false`   | Log debug messages.                                                                                                            |
+| `FORCE`                    | `true`                          | `boolean`     | `false`   | Forces synchronization of all secrets, not just kube-secret-sync managed secrets.                                              |

--- a/client/config.go
+++ b/client/config.go
@@ -1,49 +1,16 @@
 package client
 
-// StringSlice is a slice of strings
-type StringSlice []string
-
-// IsExcluded determines whether or not a given string is excluded in terms of a blacklist StringSlice
-// If the StringSlice is empty, then all provided strings are considered not excluded.
-// If the provided string exists within the StringSlice, then it is considered excluded.
-func (slice StringSlice) IsExcluded(str string) bool {
-	if len(slice) == 0 {
-		return false
-	}
-
-	for _, obj := range slice {
-		if obj == str {
-			return true
-		}
-	}
-
-	return false
-}
-
-// IsIncluded determines whether or not a given string is included in terms of a whitelist StringSlice
-// If the StringSlice is empty, then all provided strings are considered included.
-// If the StringSlice is not empty, then only strings that exist in the StringSlice will be considered included.
-func (slice StringSlice) IsIncluded(str string) bool {
-	if len(slice) == 0 {
-		return true
-	}
-
-	for _, obj := range slice {
-		if obj == str {
-			return true
-		}
-	}
-
-	return false
-}
-
 // SyncConfig contains the configuration options for the SyncSecrets operation.
 type SyncConfig struct {
-	ExcludeSecrets StringSlice
-	IncludeSecrets StringSlice
+	ExcludeSecrets      StringSlice
+	ExcludeRegexSecrets RegexSlice
+	IncludeSecrets      StringSlice
+	IncludeRegexSecrets RegexSlice
 
-	ExcludeNamespaces StringSlice
-	IncludeNamespaces StringSlice
+	ExcludeNamespaces      StringSlice
+	ExcludeRegexNamespaces RegexSlice
+	IncludeNamespaces      StringSlice
+	IncludeRegexNamespaces RegexSlice
 
 	SecretsNamespace string
 

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -65,17 +65,20 @@ func verifyNamespace(config *SyncConfig, namespace v1.Namespace) error {
 		return constants.ErrSecretsNamespace
 	}
 
-	if config.ExcludeNamespaces.IsExcluded(namespace.Name) {
+	if config.ExcludeNamespaces.IsExcluded(namespace.Name) || config.ExcludeRegexNamespaces.IsExcluded(namespace.Name) {
 		log.Debugf("[%s]: Namespace has been excluded from sync", namespace.Name)
 		return constants.ErrExcludedNamespace
 	}
 
-	if !config.IncludeNamespaces.IsIncluded(namespace.Name) {
-		log.Debugf("[%s]: Namespace is not included for sync", namespace.Name)
-		return constants.ErrNotIncludedNamespace
+	if (config.IncludeNamespaces.IsEmpty() && config.IncludeRegexNamespaces.IsEmpty()) ||
+		config.IncludeNamespaces.IsIncluded(namespace.Name) ||
+		config.IncludeRegexNamespaces.IsIncluded(namespace.Name) {
+		return nil
 	}
 
-	return nil
+	log.Debugf("[%s]: Namespace is not included for sync", namespace.Name)
+	return constants.ErrNotIncludedNamespace
+
 }
 
 func isInvalidNamespace(config *SyncConfig, namespace v1.Namespace) bool {

--- a/client/regexSlice.go
+++ b/client/regexSlice.go
@@ -1,0 +1,53 @@
+package client
+
+import (
+	"regexp"
+)
+
+// RegexSlice is a slice of compiled regular expressions
+type RegexSlice []*regexp.Regexp
+
+// CompileAll compiles a slice of strings into a RegexSlice
+func CompileAll(patterns []string) (slice RegexSlice, err error) {
+	for _, pattern := range patterns {
+		reg, err := regexp.Compile(pattern)
+		if err != nil {
+			return nil, err
+		}
+		slice = append(slice, reg)
+	}
+	return
+}
+
+// IsExcluded determines whether or not a given string is excluded in terms of a blacklist RegexSlice of regular expressions.
+// If the RegexSlice is empty, then all provided strings are considered not excluded.
+// If the provided string exists within the RegexSlice regular expressions, then it is considered excluded.
+func (slice RegexSlice) IsExcluded(str string) bool {
+	if slice.IsEmpty() {
+		return false
+	}
+
+	return slice.exists(str)
+}
+
+// IsIncluded determines whether or not a given string is included in terms of a whitelist RegexSlice of regular expressions.
+// If the RegexSlice is empty, then all provided strings are considered included.
+// If the RegexSlice is not empty, then only strings that exist in the RegexSlice regular expressions will be considered included.
+func (slice RegexSlice) IsIncluded(str string) bool {
+	return slice.exists(str)
+}
+
+func (slice RegexSlice) exists(str string) bool {
+	for _, reg := range slice {
+		if reg.MatchString(str) {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsEmpty checks if length of slice is greater than zero
+func (slice RegexSlice) IsEmpty() bool {
+	return len(slice) == 0
+}

--- a/client/stringSlice.go
+++ b/client/stringSlice.go
@@ -1,0 +1,37 @@
+package client
+
+// StringSlice is a slice of strings
+type StringSlice []string
+
+// IsExcluded determines whether or not a given string is excluded in terms of a blacklist StringSlice.
+// If the StringSlice is empty, then all provided strings are considered not excluded.
+// If the provided string exists within the StringSlice, then it is considered excluded.
+func (slice StringSlice) IsExcluded(str string) bool {
+	if slice.IsEmpty() {
+		return false
+	}
+
+	return slice.exists(str)
+}
+
+// IsIncluded determines whether or not a given string is included in terms of a whitelist StringSlice.
+// If the StringSlice is empty, then all provided strings are considered included.
+// If the StringSlice is not empty, then only strings that exist in the StringSlice will be considered included.
+func (slice StringSlice) IsIncluded(str string) bool {
+	return slice.exists(str)
+}
+
+func (slice StringSlice) exists(str string) bool {
+	for _, obj := range slice {
+		if obj == str {
+			return true
+		}
+	}
+
+	return false
+}
+
+// IsEmpty checks if length of slice is greater than zero
+func (slice StringSlice) IsEmpty() bool {
+	return len(slice) == 0
+}


### PR DESCRIPTION
This PR introduces regex matching for include/exclude secrets/namespaces. The logic for when to include/exclude is the same as before, but these new options allow for regular expressions to be supplied to perform matching. 

- The exclude check is an `OR` between both exclude lists.
- The include check first checks if both lists are empty, in which it will be considered "included". If either has values, then the secret/namespace must exist/match in at least one of them.

Closes #13 

