### PR TITLE
Sync newly created Namespaces

### DIFF
--- a/api/types/v1/secretsyncrule.go
+++ b/api/types/v1/secretsyncrule.go
@@ -23,7 +23,7 @@ type SecretSyncRuleList struct {
 	metav1.TypeMeta `json:",inline"`
 	metav1.ListMeta `json:"metadata,omitempty"`
 
-	Items []SecretSyncRule
+	Items []SecretSyncRule `json:"items"`
 }
 
 // +kubebuilder:object:generate=true

--- a/client/loggers.go
+++ b/client/loggers.go
@@ -15,5 +15,5 @@ func secretLogger(secret *v1.Secret) *log.Entry {
 }
 
 func namespaceLogger(namespace *v1.Namespace) *log.Entry {
-	return log.WithFields(log.Fields{"name": namespace.Namespace, "kind": "Namespace"})
+	return log.WithFields(log.Fields{"name": namespace.Name, "kind": "Namespace"})
 }

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -57,7 +57,7 @@ func syncSecretToNamespace(ctx context.Context, namespace *v1.Namespace, rule *t
 		return err
 	}
 
-	return createUpdateSecret(ctx, rule.Spec.Rules, *namespace, secret)
+	return createUpdateSecret(ctx, rule.Spec.Rules, namespace, secret)
 }
 
 func listNamespaces(ctx context.Context) (namespaces *v1.NamespaceList, err error) {

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -3,38 +3,61 @@ package client
 import (
 	"context"
 
+	typesv1 "github.com/alehechka/kube-secret-sync/api/types/v1"
 	log "github.com/sirupsen/logrus"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-func namespaceEventHandler(ctx context.Context, event watch.Event) {
+func namespaceEventHandler(ctx context.Context, event watch.Event) error {
 	namespace := event.Object.(*v1.Namespace)
 
 	switch event.Type {
 	case watch.Added:
-		addNamespace(ctx, namespace)
+		return addedNamespaceHandler(ctx, namespace)
 	}
+
+	return nil
 }
 
-func addNamespace(ctx context.Context, namespace *v1.Namespace) {
+func addedNamespaceHandler(ctx context.Context, namespace *v1.Namespace) error {
 	logger := namespaceLogger(namespace)
 	logger.Infof("added")
 
 	if namespace.CreationTimestamp.Time.Before(startTime) {
 		logger.Debugf("namespace will be synced on startup by SecretSyncRule watcher")
-		return
+		return nil
 	}
 
-	syncNamespace(ctx, namespace)
+	return syncNamespace(ctx, namespace)
 }
 
-// TODO - rebuild this function
 func syncNamespace(ctx context.Context, namespace *v1.Namespace) error {
 	namespaceLogger(namespace).Debugf("syncing new namespace")
 
+	rules, err := listSecretSyncRules(ctx)
+	if err != nil {
+		return err
+	}
+
+	for _, rule := range rules.Items {
+		if rule.ShouldSyncNamespace(namespace) {
+			syncSecretToNamespace(ctx, namespace, &rule)
+		}
+	}
+
 	return nil
+}
+
+func syncSecretToNamespace(ctx context.Context, namespace *v1.Namespace, rule *typesv1.SecretSyncRule) error {
+	secret, err := getSecret(ctx, rule.Spec.Namespace, rule.Spec.Secret)
+	if err != nil {
+		secretLogger(secret).Errorf("does not exist to sync: %s", err.Error())
+		return err
+	}
+
+	return createUpdateSecret(ctx, rule.Spec.Rules, *namespace, secret)
 }
 
 func listNamespaces(ctx context.Context) (namespaces *v1.NamespaceList, err error) {

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -153,13 +153,14 @@ func annotationsAreEqual(a, b map[string]string) bool {
 	if a == nil {
 		a = make(map[string]string)
 	}
+	delete(a, constants.ManagedByAnnotationKey)
+	delete(a, constants.LastAppliedConfigurationAnnotationKey)
 
 	if b == nil {
 		b = make(map[string]string)
 	}
-
-	delete(a, constants.ManagedByAnnotationKey)
 	delete(b, constants.ManagedByAnnotationKey)
+	delete(b, constants.LastAppliedConfigurationAnnotationKey)
 
 	return reflect.DeepEqual(a, b)
 }
@@ -170,6 +171,7 @@ func prepareSecret(namespace v1.Namespace, secret *v1.Secret) *v1.Secret {
 		annotations = make(map[string]string)
 	}
 	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+	delete(annotations, constants.LastAppliedConfigurationAnnotationKey)
 
 	return &v1.Secret{
 		TypeMeta: secret.TypeMeta,

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -59,7 +59,7 @@ func deleteSecrets(ctx context.Context, secret *v1.Secret) error {
 	return nil
 }
 
-func createUpdateSecret(ctx context.Context, rules typesv1.Rules, namespace v1.Namespace, secret *v1.Secret) error {
+func createUpdateSecret(ctx context.Context, rules typesv1.Rules, namespace *v1.Namespace, secret *v1.Secret) error {
 	logger := secretLogger(secret)
 
 	if namespaceSecret, err := getSecret(ctx, namespace.Name, secret.Name); err == nil {
@@ -81,7 +81,7 @@ func createUpdateSecret(ctx context.Context, rules typesv1.Rules, namespace v1.N
 	return createSecret(ctx, namespace, secret)
 }
 
-func syncDeletedSecret(ctx context.Context, rules typesv1.Rules, namespace v1.Namespace, secret *v1.Secret) error {
+func syncDeletedSecret(ctx context.Context, rules typesv1.Rules, namespace *v1.Namespace, secret *v1.Secret) error {
 	if namespaceSecret, err := getSecret(ctx, namespace.Name, secret.Name); err == nil {
 		if rules.Force || isManagedBy(namespaceSecret) {
 			return deleteSecret(ctx, namespace, secret)
@@ -92,7 +92,7 @@ func syncDeletedSecret(ctx context.Context, rules typesv1.Rules, namespace v1.Na
 	return nil
 }
 
-func createSecret(ctx context.Context, namespace v1.Namespace, secret *v1.Secret) error {
+func createSecret(ctx context.Context, namespace *v1.Namespace, secret *v1.Secret) error {
 	newSecret := prepareSecret(namespace, secret)
 
 	logger := secretLogger(newSecret)
@@ -107,7 +107,7 @@ func createSecret(ctx context.Context, namespace v1.Namespace, secret *v1.Secret
 	return err
 }
 
-func deleteSecret(ctx context.Context, namespace v1.Namespace, secret *v1.Secret) (err error) {
+func deleteSecret(ctx context.Context, namespace *v1.Namespace, secret *v1.Secret) (err error) {
 	logger := secretLogger(prepareSecret(namespace, secret))
 
 	logger.Infof("deleting secret")
@@ -120,7 +120,7 @@ func deleteSecret(ctx context.Context, namespace v1.Namespace, secret *v1.Secret
 	return
 }
 
-func updateSecret(ctx context.Context, namespace v1.Namespace, secret *v1.Secret) (err error) {
+func updateSecret(ctx context.Context, namespace *v1.Namespace, secret *v1.Secret) (err error) {
 	updateSecret := prepareSecret(namespace, secret)
 
 	logger := secretLogger(updateSecret)
@@ -165,7 +165,7 @@ func annotationsAreEqual(a, b map[string]string) bool {
 	return reflect.DeepEqual(a, b)
 }
 
-func prepareSecret(namespace v1.Namespace, secret *v1.Secret) *v1.Secret {
+func prepareSecret(namespace *v1.Namespace, secret *v1.Secret) *v1.Secret {
 	annotations := secret.Annotations
 	if annotations == nil {
 		annotations = make(map[string]string)

--- a/client/secretsyncrules.go
+++ b/client/secretsyncrules.go
@@ -5,6 +5,7 @@ import (
 
 	typesv1 "github.com/alehechka/kube-secret-sync/api/types/v1"
 	log "github.com/sirupsen/logrus"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/watch"
 )
 
@@ -53,4 +54,12 @@ func modifySecretSyncRule(ctx context.Context, rule *typesv1.SecretSyncRule) {
 
 func deleteSecretSyncRule(ctx context.Context, rule *typesv1.SecretSyncRule) {
 	ruleLogger(rule).Infof("deleted")
+}
+
+func listSecretSyncRules(ctx context.Context) (rules *typesv1.SecretSyncRuleList, err error) {
+	rules, err = KubeSecretSyncClientset.SecretSyncRules().List(ctx, metav1.ListOptions{})
+	if err != nil {
+		log.Errorf("failed to list SecretSyncRules: %s", err.Error())
+	}
+	return
 }

--- a/client/secretsyncrules.go
+++ b/client/secretsyncrules.go
@@ -41,7 +41,7 @@ func addSecretSyncRule(ctx context.Context, rule *typesv1.SecretSyncRule) error 
 
 	for _, namespace := range namespaces.Items {
 		if rule.ShouldSyncNamespace(&namespace) {
-			createUpdateSecret(ctx, rule.Spec.Rules, namespace, secret)
+			createUpdateSecret(ctx, rule.Spec.Rules, &namespace, secret)
 		}
 	}
 

--- a/constants/annotations.go
+++ b/constants/annotations.go
@@ -5,3 +5,6 @@ const ManagedByAnnotationKey = "app.kubernetes.io/managed-by"
 
 // ManagedByAnnotationValue is an annotation value appended to kube-secret-sync managed secrets.
 const ManagedByAnnotationValue = "kube-secret-sync"
+
+// LastAppliedConfigurationAnnotationKey is an annotation created by Kubernetes to keep track of last config
+const LastAppliedConfigurationAnnotationKey = "kubectl.kubernetes.io/last-applied-configuration"


### PR DESCRIPTION
This PR adds the ability to sync secrets to newly created Namespaces. The general process is the following:
- Check if namespace `CreationTimestamp` is newer than the application `startTime`
- Pull `SecretSyncRule` list
- Loop over the list and check if Namespace is syncable for each iterated rule
- Create/update the secret

Also had to make a slight adjustment to the following:
- SecretSyncRuleList object needed a `json` tag to pull data correctly
- `namespaceLogger` was not printing the name of the Namespace
- Discovered that the `kubectl.kubernetes.io/last-applied-configuration` annotation was getting copied to secrets and could potentially cause equality issues.
  - Removed from equality check
  - Removed from `prepareSecret` func