### PR TITLE
Sync Deleted Secrets

### DIFF
--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -12,7 +12,11 @@ import (
 )
 
 func namespaceEventHandler(ctx context.Context, event watch.Event) error {
-	namespace := event.Object.(*v1.Namespace)
+	namespace, ok := event.Object.(*v1.Namespace)
+	if !ok {
+		log.Error("failed to cast Namespace")
+		return nil
+	}
 
 	switch event.Type {
 	case watch.Added:

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -96,7 +96,6 @@ func createUpdateSecret(ctx context.Context, rules typesv1.Rules, namespace *v1.
 	return createSecret(ctx, namespace, secret)
 }
 
-// TODO - rebuild this function
 func deletedSecretHandler(ctx context.Context, secret *v1.Secret) error {
 	secretLogger(secret).Infof("deleted")
 

--- a/client/secretsyncrules.go
+++ b/client/secretsyncrules.go
@@ -10,20 +10,23 @@ import (
 	"k8s.io/apimachinery/pkg/watch"
 )
 
-func secretSyncRuleEventHandler(ctx context.Context, event watch.Event) {
+func secretSyncRuleEventHandler(ctx context.Context, event watch.Event) error {
 	rule, ok := event.Object.(*typesv1.SecretSyncRule)
 	if !ok {
 		log.Error("failed to cast SecretSyncRule")
+		return nil
 	}
 
 	switch event.Type {
 	case watch.Added:
-		addedSecretSyncRuleHandler(ctx, rule)
+		return addedSecretSyncRuleHandler(ctx, rule)
 	case watch.Modified:
-		modifiedSecretSyncRuleHandler(ctx, rule)
+		return modifiedSecretSyncRuleHandler(ctx, rule)
 	case watch.Deleted:
-		deletedSecretSyncRuleHandler(ctx, rule)
+		return deletedSecretSyncRuleHandler(ctx, rule)
 	}
+
+	return nil
 }
 
 func addedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRule) error {
@@ -41,12 +44,14 @@ func addedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRul
 	return nil
 }
 
-func modifiedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRule) {
+func modifiedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRule) error {
 	ruleLogger(rule).Infof("modified")
+	return nil
 }
 
-func deletedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRule) {
+func deletedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRule) error {
 	ruleLogger(rule).Infof("deleted")
+	return nil
 }
 
 func listSecretSyncRules(ctx context.Context) (rules *typesv1.SecretSyncRuleList, err error) {

--- a/k8s/3_secret.yaml
+++ b/k8s/3_secret.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+  namespace: kube-secret-sync
+type: Opaque
+data:
+  username: YWRtaW4=
+  password: MWYyZDFlMmU2N2Rm

--- a/k8s/4_secretsyncrule.yaml
+++ b/k8s/4_secretsyncrule.yaml
@@ -1,13 +1,3 @@
-apiVersion: v1
-kind: Secret
-metadata:
-  name: mysecret
-  namespace: kube-secret-sync
-type: Opaque
-data:
-  username: YWRtaW4=
-  password: MWYyZDFlMmU2N2Rm
----
 apiVersion: kube-secret-sync.io/v1
 kind: SecretSyncRule
 metadata:


### PR DESCRIPTION
This smaller PR simply adds the ability to synchronize deleted secrets.

Also adds in a casting short-circuit check to each of the watcher handlers.