### PR TITLE
Error handling for closed watchers

### DIFF
--- a/client/init.go
+++ b/client/init.go
@@ -31,22 +31,34 @@ func initClientsets(config *clientset.SyncConfig) error {
 }
 
 func initWatchers(ctx context.Context) (secretWatcher watch.Interface, namespaceWatcher watch.Interface, secretSyncRuleWatcher watch.Interface, err error) {
-	secretWatcher, err = clientset.Default.CoreV1().Secrets(v1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
+	secretWatcher, err = SecretWatcher(ctx)
 	if err != nil {
 		return
 	}
 
-	namespaceWatcher, err = clientset.Default.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{})
+	namespaceWatcher, err = NamespaceWatcher(ctx)
 	if err != nil {
 		return
 	}
 
-	secretSyncRuleWatcher, err = kssclientset.KubeSecretSync.SecretSyncRules().Watch(ctx, metav1.ListOptions{})
+	secretSyncRuleWatcher, err = SecretSyncRuleWatcher(ctx)
 	if err != nil {
 		return
 	}
 
 	return
+}
+
+func SecretWatcher(ctx context.Context) (watch.Interface, error) {
+	return clientset.Default.CoreV1().Secrets(v1.NamespaceAll).Watch(ctx, metav1.ListOptions{})
+}
+
+func NamespaceWatcher(ctx context.Context) (watch.Interface, error) {
+	return clientset.Default.CoreV1().Namespaces().Watch(ctx, metav1.ListOptions{})
+}
+
+func SecretSyncRuleWatcher(ctx context.Context) (watch.Interface, error) {
+	return kssclientset.KubeSecretSync.SecretSyncRules().Watch(ctx, metav1.ListOptions{})
 }
 
 func initSignalChannel() (sigc chan os.Signal) {


### PR DESCRIPTION
When leaving the application running while going AFK, I noticed that the console would show hundreds of error messages for casting the `SecretSyncRule` and and eventual panic when not handled correctly for casting `Secrets`. Some googleing showed me this issue thread: https://github.com/kubernetes/client-go/issues/334, where it seems common for the watcher to eventually get closed due to the HTTP client timing out. 

To resolve this, I added a check to each watcher that when closed, will attempt to re-open the watcher, if it errors again than the application will terminate. 