### PR TITLE
Sync Deleted SecretSyncRules

### DIFF
--- a/client/secretsyncrules.go
+++ b/client/secretsyncrules.go
@@ -51,6 +51,16 @@ func modifiedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSync
 
 func deletedSecretSyncRuleHandler(ctx context.Context, rule *typesv1.SecretSyncRule) error {
 	ruleLogger(rule).Infof("deleted")
+
+	secret, err := getSecret(ctx, rule.Spec.Namespace, rule.Spec.Secret)
+	if err != nil {
+		return err
+	}
+
+	for _, namespace := range rule.Namespaces(ctx) {
+		syncDeletedSecret(ctx, rule.Spec.Rules, &namespace, secret)
+	}
+
 	return nil
 }
 

--- a/client/sync.go
+++ b/client/sync.go
@@ -27,9 +27,9 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 		return err
 	}
 
-	defer secretSyncRuleWatcher.Stop()
 	defer secretWatcher.Stop()
 	defer namespaceWatcher.Stop()
+	defer secretSyncRuleWatcher.Stop()
 
 	signalChan := initSignalChannel()
 
@@ -41,6 +41,7 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 				if secretWatcher, err = SecretWatcher(ctx); err != nil {
 					return err
 				}
+				defer secretWatcher.Stop()
 				continue
 			}
 			secretEventHandler(ctx, secretEvent)
@@ -50,6 +51,7 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 				if namespaceWatcher, err = NamespaceWatcher(ctx); err != nil {
 					return err
 				}
+				defer namespaceWatcher.Stop()
 				continue
 			}
 			namespaceEventHandler(ctx, namespaceEvent)
@@ -59,6 +61,7 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 				if secretSyncRuleWatcher, err = SecretSyncRuleWatcher(ctx); err != nil {
 					return err
 				}
+				defer secretSyncRuleWatcher.Stop()
 				continue
 			}
 			secretSyncRuleEventHandler(ctx, secretSyncRuleEvent)

--- a/client/sync.go
+++ b/client/sync.go
@@ -37,6 +37,7 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 		select {
 		case secretEvent, ok := <-secretWatcher.ResultChan():
 			if !ok {
+				log.Debug("Secret watcher timed out, restarting now.")
 				if secretWatcher, err = SecretWatcher(ctx); err != nil {
 					return err
 				}
@@ -45,6 +46,7 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 			secretEventHandler(ctx, secretEvent)
 		case namespaceEvent, ok := <-namespaceWatcher.ResultChan():
 			if !ok {
+				log.Debug("Namespace watcher timed out, restarting now.")
 				if namespaceWatcher, err = NamespaceWatcher(ctx); err != nil {
 					return err
 				}
@@ -53,6 +55,7 @@ func SyncSecrets(config *clientset.SyncConfig) (err error) {
 			namespaceEventHandler(ctx, namespaceEvent)
 		case secretSyncRuleEvent, ok := <-secretSyncRuleWatcher.ResultChan():
 			if !ok {
+				log.Debug("SecretSyncRule watcher timed out, restarting now.")
 				if secretSyncRuleWatcher, err = SecretSyncRuleWatcher(ctx); err != nil {
 					return err
 				}


### PR DESCRIPTION
The primary purpose of this PR is to add the ability to sync deleted `SecretSyncRules`. When this event occurs, all managed/forced secrets will be deleted. The original secret that the `SecretSyncRule` is syncing from will not be impacted.

Additionally, I added some debug logging to the watcher restarts to make it a little clearer what is happening when a new series of log messages pour in. 