### PR TITLE
Resolve Helm chart release process

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -91,14 +91,17 @@ jobs:
 
           echo "::set-output name=version::${VERSION##*v}"
 
+      - name: Update versions
+        run: |
+          yq --inplace '.image.tag = "${{ github.ref_name }}"' values.yaml
+          yq --inplace '.version = "${{ steps.chart.outputs.version }}" | .appVersion = "${{ github.ref_name }}"' Chart.yaml
+        working_directory: deploy/helm/kube-secret-sync
+
       - name: Build Template
-        run: helm template kube-secret-sync deploy/helm/kube-secret-sync --set image.tag=${{ github.ref_name }} > kube-secret-sync.yaml
+        run: helm template kube-secret-sync deploy/helm/kube-secret-sync > kube-secret-sync.yaml
 
       - name: Build Package
-        run: |
-          yq --inplace '.image.tag = "${{ github.ref_name }}"' deploy/helm/kube-secret-sync/values.yaml
-
-          helm package deploy/helm/kube-secret-sync --app-version=${{ github.ref_name }} --version=${{ steps.chart.outputs.version }}
+        run: helm package deploy/helm/kube-secret-sync
 
       - name: Add to release
         run: gh release upload ${{ github.ref_name }} kube-secret-sync.yaml kube-secret-sync-${{ steps.chart.outputs.version }}.tgz


### PR DESCRIPTION
The recent [v1.0.0](https://github.com/alehechka/kube-secret-sync/releases/tag/v1.0.0) release had a malformed `kube-secret-sync.yaml` uploaded. The file had incorrect versions due to `Chart.yaml` not including it. 

This PR makes it so both `values.yaml` and `Chart.yaml` are updated prior to tempalte/package.