### PR TITLE
Resolve Namespace provision with helm

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,7 @@ jobs:
         working_directory: deploy/helm/kube-secret-sync
 
       - name: Build Template
-        run: helm template kube-secret-sync deploy/helm/kube-secret-sync > kube-secret-sync.yaml
+        run: helm template --namespace kube-secret-sync kube-secret-sync deploy/helm/kube-secret-sync > kube-secret-sync.yaml
 
       - name: Build Package
         run: helm package deploy/helm/kube-secret-sync

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,7 +101,11 @@ jobs:
         run: helm template --namespace kube-secret-sync kube-secret-sync deploy/helm/kube-secret-sync > kube-secret-sync.yaml
 
       - name: Build Package
-        run: helm package deploy/helm/kube-secret-sync
+        run: |
+        # package can't include namespace definition
+        rm deploy/helm/kube-secret-sync/templates/namespace.yaml
+
+        helm package deploy/helm/kube-secret-sync
 
       - name: Add to release
         run: gh release upload ${{ github.ref_name }} kube-secret-sync.yaml kube-secret-sync-${{ steps.chart.outputs.version }}.tgz

--- a/README.md
+++ b/README.md
@@ -11,13 +11,13 @@ Each released version will create a package helm chart and compiled yaml to depl
 ### `helm`
 
 ```bash
-helm install kube-secret-sync https://github.com/alehechka/kube-secret-sync/releases/download/v1.0.0/kube-secret-sync-1.0.0.tgz
+helm install kube-secret-sync https://github.com/alehechka/kube-secret-sync/releases/download/v1.1.0/kube-secret-sync-1.1.0.tgz --namespace kube-secret-sync --create-namespace
 ```
 
 ### `kubectl`
 
 ```bash
-kubectl apply -f https://github.com/alehechka/kube-secret-sync/releases/download/v1.0.0/kube-secret-sync.yaml
+kubectl apply -f https://github.com/alehechka/kube-secret-sync/releases/download/v1.1.0/kube-secret-sync.yaml
 ```
 
 ## Secret Sync Rules

--- a/deploy/helm/kube-secret-sync/templates/clusterrolebinding.yaml
+++ b/deploy/helm/kube-secret-sync/templates/clusterrolebinding.yaml
@@ -10,4 +10,4 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: {{ include "kube-secret-sync.serviceAccountName" . }}
-    namespace: {{ .Values.namespace }}
+    namespace: {{ .Release.Namespace }}

--- a/deploy/helm/kube-secret-sync/templates/deployment.yaml
+++ b/deploy/helm/kube-secret-sync/templates/deployment.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ include "kube-secret-sync.fullname" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels: {{- include "kube-secret-sync.labels" . | nindent 4 }}
 spec:
   replicas: {{ .Values.replicaCount }}

--- a/deploy/helm/kube-secret-sync/templates/namespace.yaml
+++ b/deploy/helm/kube-secret-sync/templates/namespace.yaml
@@ -1,5 +1,5 @@
 kind: Namespace
 apiVersion: v1
 metadata:
-  name: {{ .Values.namespace }}
+  name: {{ .Release.Namespace }}
   labels: {{- include "kube-secret-sync.labels" . | nindent 4 }}

--- a/deploy/helm/kube-secret-sync/templates/serviceaccount.yaml
+++ b/deploy/helm/kube-secret-sync/templates/serviceaccount.yaml
@@ -3,7 +3,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: {{ include "kube-secret-sync.serviceAccountName" . }}
-  namespace: {{ .Values.namespace }}
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "kube-secret-sync.labels" . | nindent 4 }}
   {{- with .Values.serviceAccount.annotations }}

--- a/deploy/helm/kube-secret-sync/values.yaml
+++ b/deploy/helm/kube-secret-sync/values.yaml
@@ -14,8 +14,6 @@ imagePullSecrets: []
 nameOverride: 'kube-secret-sync'
 fullnameOverride: 'kube-secret-sync'
 
-namespace: kube-secret-sync
-
 serviceAccount:
   # Specifies whether a service account should be created
   create: true


### PR DESCRIPTION
Through further use of helm, it was found that the recommended way to provide a helm chart is without the namespace predefined so that the user has an easier time specifying their own namespace to deploy resources to.

For this, all resources have had their namespace changed to the `.Release.Namespace` version which is provided on install. 

The release process will now create the template with a provided `.Release.Namespace` and also include the creation of the namespace.

Unfortunately, helm doesn't like having you create a namespace and wants to do it itself, so the release of the package will first delete the `namespace.yaml` then package. And the README has been updated to show full command usage with specifying a namespace and creating it on install.