### PR TITLE
Refactor Logging and add OwnerReference to synced Secrets

### DIFF
--- a/api/types/v1/clientset/register.go
+++ b/api/types/v1/clientset/register.go
@@ -9,6 +9,7 @@ import (
 
 const GroupName = "kube-secret-sync.io"
 const GroupVersion = "v1"
+const SecretSyncRule = "SecretSyncRule"
 
 var SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
 

--- a/client/annotations.go
+++ b/client/annotations.go
@@ -1,0 +1,48 @@
+package client
+
+import (
+	"reflect"
+
+	typesv1 "github.com/alehechka/kube-secret-sync/api/types/v1"
+	"github.com/alehechka/kube-secret-sync/api/types/v1/clientset"
+	"github.com/alehechka/kube-secret-sync/constants"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/uuid"
+)
+
+func AnnotationsAreEqual(a, b map[string]string) bool {
+	aCopy := CopyAnnotations(a)
+	bCopy := CopyAnnotations(b)
+
+	return reflect.DeepEqual(aCopy, bCopy)
+}
+
+func CopyAnnotations(m map[string]string) map[string]string {
+	copy := make(map[string]string)
+
+	for key, value := range m {
+		if key == constants.ManagedByAnnotationKey || key == constants.LastAppliedConfigurationAnnotationKey {
+			continue
+		}
+		copy[key] = value
+	}
+
+	return copy
+}
+
+func Manage(m map[string]string) map[string]string {
+	if m == nil {
+		m = make(map[string]string)
+	}
+	m[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+	return m
+}
+
+func OwnerReference(rule *typesv1.SecretSyncRule) metav1.OwnerReference {
+	return metav1.OwnerReference{
+		APIVersion: clientset.GroupName,
+		Kind:       clientset.SecretSyncRule,
+		Name:       rule.Name,
+		UID:        uuid.NewUUID(),
+	}
+}

--- a/client/data_test.go
+++ b/client/data_test.go
@@ -1,6 +1,7 @@
 package client_test
 
 import (
+	typesv1 "github.com/alehechka/kube-secret-sync/api/types/v1"
 	"github.com/alehechka/kube-secret-sync/constants"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -19,3 +20,4 @@ var testNamespace = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: keyTestNam
 var defaultNamespace = &v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: keyDefault}}
 var defaultSecret = &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: keyDefaultSecret, Namespace: keyDefault}}
 var testSecret = &v1.Secret{ObjectMeta: metav1.ObjectMeta{Name: keyTestSecret, Namespace: keyTestSecret}}
+var testSecretSyncRule = &typesv1.SecretSyncRule{Spec: typesv1.SecretSyncRuleSpec{Secret: typesv1.Secret{Name: keyDefaultSecret, Namespace: keyDefault}}}

--- a/client/loggers.go
+++ b/client/loggers.go
@@ -7,13 +7,30 @@ import (
 )
 
 func ruleLogger(rule *typesv1.SecretSyncRule) *log.Entry {
-	return log.WithFields(log.Fields{"name": rule.Name, "kind": "SecretSyncRule"})
+	return ruleNameLogger(rule.Name)
 }
 
-func secretLogger(secret *v1.Secret) *log.Entry {
-	return log.WithFields(log.Fields{"name": secret.Name, "kind": "Secret", "namespace": secret.Namespace})
+func ruleNameLogger(name string) *log.Entry {
+	return log.WithFields(log.Fields{"name": name, "kind": "SecretSyncRule"})
 }
 
 func namespaceLogger(namespace *v1.Namespace) *log.Entry {
-	return log.WithFields(log.Fields{"name": namespace.Name, "kind": "Namespace"})
+	return namespaceNameLogger(namespace.Name)
+}
+
+func namespaceNameLogger(namespace string) *log.Entry {
+	return log.WithFields(log.Fields{"name": namespace, "kind": "Namespace"})
+}
+
+func secretLogger(secret *v1.Secret, namespaces ...*v1.Namespace) *log.Entry {
+	namespace := secret.Namespace
+	if len(namespaces) > 0 {
+		namespace = namespaces[0].Name
+	}
+
+	return secretNameLogger(namespace, secret.Name)
+}
+
+func secretNameLogger(namespace, name string) *log.Entry {
+	return log.WithFields(log.Fields{"name": name, "kind": "Secret", "namespace": namespace})
 }

--- a/client/namespaces.go
+++ b/client/namespaces.go
@@ -45,20 +45,20 @@ func (client *Client) SyncNamespace(namespace *v1.Namespace) error {
 
 	for _, rule := range rules.Items {
 		if rule.ShouldSyncNamespace(namespace) {
-			client.SyncSecretToNamespace(namespace, &rule)
+			client.SyncSecretToNamespace(&rule, namespace)
 		}
 	}
 
 	return nil
 }
 
-func (client *Client) SyncSecretToNamespace(namespace *v1.Namespace, rule *typesv1.SecretSyncRule) error {
+func (client *Client) SyncSecretToNamespace(rule *typesv1.SecretSyncRule, namespace *v1.Namespace) error {
 	secret, err := client.GetSecret(rule.Spec.Secret.Namespace, rule.Spec.Secret.Name)
 	if err != nil {
 		return err
 	}
 
-	return client.CreateUpdateSecret(rule.Spec.Rules, namespace, secret)
+	return client.CreateUpdateSecret(rule, namespace, secret)
 }
 
 func (client *Client) ListNamespaces() (namespaces *v1.NamespaceList, err error) {

--- a/client/namespaces_test.go
+++ b/client/namespaces_test.go
@@ -3,8 +3,6 @@ package client_test
 import (
 	"testing"
 
-	typesv1 "github.com/alehechka/kube-secret-sync/api/types/v1"
-
 	"github.com/stretchr/testify/assert"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -12,9 +10,9 @@ import (
 func Test_SyncSecretToNamespace(t *testing.T) {
 	client := InitializeTestClientset()
 
-	client.CreateSecret(defaultNamespace, defaultSecret)
+	client.CreateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 
-	err := client.SyncSecretToNamespace(testNamespace, &typesv1.SecretSyncRule{Spec: typesv1.SecretSyncRuleSpec{Secret: typesv1.Secret{Name: keyDefaultSecret, Namespace: keyDefault}}})
+	err := client.SyncSecretToNamespace(testSecretSyncRule, testNamespace)
 
 	assert.NoError(t, err)
 }
@@ -22,7 +20,7 @@ func Test_SyncSecretToNamespace(t *testing.T) {
 func Test_SyncSecretToNamespace_NoSecret(t *testing.T) {
 	client := InitializeTestClientset()
 
-	err := client.SyncSecretToNamespace(testNamespace, &typesv1.SecretSyncRule{Spec: typesv1.SecretSyncRuleSpec{Secret: typesv1.Secret{Name: keyDefaultSecret, Namespace: keyDefault}}})
+	err := client.SyncSecretToNamespace(testSecretSyncRule, testNamespace)
 
 	assert.Error(t, err)
 }

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -195,8 +195,7 @@ func SecretsAreEqual(a, b *v1.Secret) bool {
 }
 
 func PrepareSecret(rule *typesv1.SecretSyncRule, namespace *v1.Namespace, secret *v1.Secret) *v1.Secret {
-	annotations := CopyAnnotations(secret.Annotations)
-	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
+	annotations := Manage(CopyAnnotations(secret.Annotations))
 
 	return &v1.Secret{
 		TypeMeta: secret.TypeMeta,

--- a/client/secrets.go
+++ b/client/secrets.go
@@ -64,7 +64,7 @@ func (client *Client) SyncAddedModifiedSecret(secret *v1.Secret) error {
 	for _, rule := range rules.Items {
 		if rule.ShouldSyncSecret(secret) {
 			for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {
-				client.CreateUpdateSecret(rule.Spec.Rules, &namespace, secret)
+				client.CreateUpdateSecret(&rule, &namespace, secret)
 			}
 		}
 	}
@@ -72,13 +72,13 @@ func (client *Client) SyncAddedModifiedSecret(secret *v1.Secret) error {
 	return nil
 }
 
-func (client *Client) CreateUpdateSecret(rules typesv1.Rules, namespace *v1.Namespace, secret *v1.Secret) error {
-	logger := secretLogger(PrepareSecret(namespace, secret))
+func (client *Client) CreateUpdateSecret(rule *typesv1.SecretSyncRule, namespace *v1.Namespace, secret *v1.Secret) error {
+	logger := secretLogger(secret, namespace)
 
 	if namespaceSecret, err := client.GetSecret(namespace.Name, secret.Name); err == nil {
 		logger.Debugf("already exists")
 
-		if !rules.Force && !IsManagedBy(namespaceSecret) {
+		if !rule.Spec.Rules.Force && !IsManagedBy(namespaceSecret) {
 			logger.Debugf("existing secret is not managed and will not be force updated")
 			return nil
 		}
@@ -88,10 +88,10 @@ func (client *Client) CreateUpdateSecret(rules typesv1.Rules, namespace *v1.Name
 			return nil
 		}
 
-		return client.UpdateSecret(namespace, secret)
+		return client.UpdateSecret(rule, namespace, secret)
 	}
 
-	return client.CreateSecret(namespace, secret)
+	return client.CreateSecret(rule, namespace, secret)
 }
 
 func (client *Client) DeletedSecretHandler(secret *v1.Secret) error {
@@ -114,7 +114,7 @@ func (client *Client) DeletedSecretHandler(secret *v1.Secret) error {
 }
 
 func (client *Client) SyncDeletedSecret(rules typesv1.Rules, namespace *v1.Namespace, secret *v1.Secret) error {
-	logger := secretLogger(PrepareSecret(namespace, secret))
+	logger := secretLogger(secret, namespace)
 
 	if namespaceSecret, err := client.GetSecret(namespace.Name, secret.Name); err == nil {
 		if rules.Force || IsManagedBy(namespaceSecret) {
@@ -127,8 +127,8 @@ func (client *Client) SyncDeletedSecret(rules typesv1.Rules, namespace *v1.Names
 	return nil
 }
 
-func (client *Client) CreateSecret(namespace *v1.Namespace, secret *v1.Secret) error {
-	newSecret := PrepareSecret(namespace, secret)
+func (client *Client) CreateSecret(rule *typesv1.SecretSyncRule, namespace *v1.Namespace, secret *v1.Secret) error {
+	newSecret := PrepareSecret(rule, namespace, secret)
 
 	logger := secretLogger(newSecret)
 	logger.Infof("creating secret")
@@ -142,8 +142,8 @@ func (client *Client) CreateSecret(namespace *v1.Namespace, secret *v1.Secret) e
 	return err
 }
 
-func (client *Client) UpdateSecret(namespace *v1.Namespace, secret *v1.Secret) (err error) {
-	updateSecret := PrepareSecret(namespace, secret)
+func (client *Client) UpdateSecret(rule *typesv1.SecretSyncRule, namespace *v1.Namespace, secret *v1.Secret) (err error) {
+	updateSecret := PrepareSecret(rule, namespace, secret)
 
 	logger := secretLogger(updateSecret)
 	logger.Infof("updating secret")
@@ -157,7 +157,7 @@ func (client *Client) UpdateSecret(namespace *v1.Namespace, secret *v1.Secret) (
 }
 
 func (client *Client) DeleteSecret(namespace *v1.Namespace, secret *v1.Secret) (err error) {
-	logger := secretLogger(PrepareSecret(namespace, secret))
+	logger := secretLogger(secret, namespace)
 
 	logger.Infof("deleting secret")
 
@@ -172,7 +172,7 @@ func (client *Client) DeleteSecret(namespace *v1.Namespace, secret *v1.Secret) (
 func (client *Client) GetSecret(namespace, name string) (secret *v1.Secret, err error) {
 	secret, err = client.DefaultClientset.CoreV1().Secrets(namespace).Get(client.Context, name, metav1.GetOptions{})
 	if err != nil {
-		secretLogger(&v1.Secret{ObjectMeta: metav1.ObjectMeta{Namespace: namespace, Name: name}}).
+		secretNameLogger(namespace, name).
 			Errorf("failed to get secret: %s", err.Error())
 	}
 	return
@@ -181,7 +181,7 @@ func (client *Client) GetSecret(namespace, name string) (secret *v1.Secret, err 
 func (client *Client) ListSecrets(namespace string) (list *v1.SecretList, err error) {
 	list, err = client.DefaultClientset.CoreV1().Secrets(namespace).List(client.Context, metav1.ListOptions{})
 	if err != nil {
-		namespaceLogger(&v1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: namespace}}).
+		namespaceNameLogger(namespace).
 			Errorf("failed to list secrets: %s", err.Error())
 	}
 	return
@@ -194,24 +194,18 @@ func SecretsAreEqual(a, b *v1.Secret) bool {
 		AnnotationsAreEqual(a.Annotations, b.Annotations))
 }
 
-func AnnotationsAreEqual(a, b map[string]string) bool {
-	aCopy := CopyAnnotations(a)
-	bCopy := CopyAnnotations(b)
-
-	return reflect.DeepEqual(aCopy, bCopy)
-}
-
-func PrepareSecret(namespace *v1.Namespace, secret *v1.Secret) *v1.Secret {
+func PrepareSecret(rule *typesv1.SecretSyncRule, namespace *v1.Namespace, secret *v1.Secret) *v1.Secret {
 	annotations := CopyAnnotations(secret.Annotations)
 	annotations[constants.ManagedByAnnotationKey] = constants.ManagedByAnnotationValue
 
 	return &v1.Secret{
 		TypeMeta: secret.TypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        secret.Name,
-			Namespace:   namespace.Name,
-			Labels:      secret.Labels,
-			Annotations: annotations,
+			Name:            secret.Name,
+			Namespace:       namespace.Name,
+			Labels:          secret.Labels,
+			Annotations:     annotations,
+			OwnerReferences: []metav1.OwnerReference{OwnerReference(rule)},
 		},
 		Immutable:  secret.Immutable,
 		Data:       secret.Data,
@@ -219,19 +213,6 @@ func PrepareSecret(namespace *v1.Namespace, secret *v1.Secret) *v1.Secret {
 		Type:       secret.Type,
 	}
 
-}
-
-func CopyAnnotations(m map[string]string) map[string]string {
-	copy := make(map[string]string)
-
-	for key, value := range m {
-		if key == constants.ManagedByAnnotationKey || key == constants.LastAppliedConfigurationAnnotationKey {
-			continue
-		}
-		copy[key] = value
-	}
-
-	return copy
 }
 
 func IsManagedBy(secret *v1.Secret) bool {

--- a/client/secrets_test.go
+++ b/client/secrets_test.go
@@ -12,7 +12,7 @@ import (
 func Test_ListSecrets(t *testing.T) {
 	client := InitializeTestClientset()
 
-	client.CreateSecret(defaultNamespace, defaultSecret)
+	client.CreateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 
 	secrets, err := client.ListSecrets(keyDefault)
 
@@ -34,7 +34,7 @@ func Test_ListSecrets_Empty(t *testing.T) {
 func Test_GetSecret(t *testing.T) {
 	client := InitializeTestClientset()
 
-	client.CreateSecret(defaultNamespace, defaultSecret)
+	client.CreateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 
 	secret, err := client.GetSecret(keyDefault, keyDefaultSecret)
 
@@ -54,7 +54,7 @@ func Test_GetSecret_NoSecret(t *testing.T) {
 func Test_DeleteSecret(t *testing.T) {
 	client := InitializeTestClientset()
 
-	client.CreateSecret(defaultNamespace, defaultSecret)
+	client.CreateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 
 	err := client.DeleteSecret(defaultNamespace, defaultSecret)
 
@@ -72,9 +72,9 @@ func Test_DeleteSecret_NoSecret(t *testing.T) {
 func Test_UpdateSecret(t *testing.T) {
 	client := InitializeTestClientset()
 
-	client.CreateSecret(defaultNamespace, defaultSecret)
+	client.CreateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 
-	err := client.UpdateSecret(defaultNamespace, defaultSecret)
+	err := client.UpdateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 
 	assert.NoError(t, err)
 }
@@ -82,7 +82,7 @@ func Test_UpdateSecret(t *testing.T) {
 func Test_UpdateSecret_NoSecret(t *testing.T) {
 	client := InitializeTestClientset()
 
-	err := client.UpdateSecret(testNamespace, testSecret)
+	err := client.UpdateSecret(testSecretSyncRule, testNamespace, testSecret)
 
 	assert.Error(t, err)
 }
@@ -90,7 +90,7 @@ func Test_UpdateSecret_NoSecret(t *testing.T) {
 func Test_CreateSecret(t *testing.T) {
 	client := InitializeTestClientset()
 
-	err := client.CreateSecret(defaultNamespace, defaultSecret)
+	err := client.CreateSecret(testSecretSyncRule, defaultNamespace, defaultSecret)
 	assert.NoError(t, err)
 
 	secret, err := client.GetSecret(keyDefault, keyDefaultSecret)
@@ -170,7 +170,7 @@ func Test_PrepareSecret(t *testing.T) {
 	secret := *defaultSecret
 	secret.Annotations = map[string]string{constants.LastAppliedConfigurationAnnotationKey: "some-previous-config", "some-key": "some-value"}
 
-	prepared := pkg.PrepareSecret(testNamespace, &secret)
+	prepared := pkg.PrepareSecret(testSecretSyncRule, testNamespace, &secret)
 
 	assert.True(t, pkg.SecretsAreEqual(&secret, prepared))
 	assert.True(t, pkg.IsManagedBy(prepared))

--- a/client/secretsyncrules.go
+++ b/client/secretsyncrules.go
@@ -35,7 +35,7 @@ func (client *Client) AddedSecretSyncRuleHandler(rule *typesv1.SecretSyncRule) e
 	}
 
 	for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {
-		client.CreateUpdateSecret(rule.Spec.Rules, &namespace, secret)
+		client.CreateUpdateSecret(rule, &namespace, secret)
 	}
 
 	return nil
@@ -59,7 +59,7 @@ func (client *Client) ModifiedSecretSyncRuleHandler(rule *typesv1.SecretSyncRule
 	}
 
 	for _, namespace := range rule.Namespaces(client.Context, client.DefaultClientset) {
-		client.CreateUpdateSecret(rule.Spec.Rules, &namespace, secret)
+		client.CreateUpdateSecret(rule, &namespace, secret)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
+	github.com/google/uuid v1.1.2 // indirect
 	github.com/imdario/mergo v0.3.6 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -128,6 +128,8 @@ github.com/google/pprof v0.0.0-20200229191704-1ebb73c60ed3/go.mod h1:ZgVRPoUq/hf
 github.com/google/pprof v0.0.0-20200430221834-fc25d7d30c6d/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/pprof v0.0.0-20200708004538-1a94d8640e99/go.mod h1:ZgVRPoUq/hfqzAqh7sHMqb3I9Rq5C59dIz2SbBwJ4eM=
 github.com/google/renameio v0.1.0/go.mod h1:KWCgfxg9yswjAJkECMjeO8J8rahYeXnNhOm40UhjYkI=
+github.com/google/uuid v1.1.2 h1:EVhdT+1Kseyi1/pUmXKaFxYsDNy9RQYkMWRH68J/W7Y=
+github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=
 github.com/googleapis/gax-go/v2 v2.0.4/go.mod h1:0Wqv26UfaUD9n4G6kQubkQ+KchISgw+vpHVxEJEs9eg=
 github.com/googleapis/gax-go/v2 v2.0.5/go.mod h1:DWXyrwAJ9X0FpwwEdw+IPEYBICEFu5mhpdKc/us6bOk=
 github.com/hashicorp/golang-lru v0.5.0/go.mod h1:/m3WP610KZHVQ1SGc6re/UDhFvYD7pJ4Ao+sR/qLZy8=


### PR DESCRIPTION
Refactor logging functions to allow easier usage. 

Adding OwnerReference to prepared secrets to further show what created the synced secrets.